### PR TITLE
#76 allow users to download an ICS file for an event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3577,6 +3577,11 @@
         "repeating": "^2.0.0"
       }
     },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+    },
     "di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
@@ -3919,6 +3924,11 @@
         "es6-symbol": "~3.1.1",
         "next-tick": "1"
       }
+    },
+    "es6-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-1.0.0.tgz",
+      "integrity": "sha1-fuCojLEvPL7uS10ug02kq1sP05Y="
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -6227,6 +6237,39 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "ics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/ics/-/ics-2.9.0.tgz",
+      "integrity": "sha512-H3HuC+NfYvoA+bhTWmeCslReHq546eBnq6KT4m6ALJTx8xLq6QaToVQucKjP3LPnMSw/vqwILZHRm2ID8LW9yw==",
+      "requires": {
+        "joi": "^10.6.0",
+        "lodash": "^4.17.4",
+        "moment": "^2.18.1",
+        "uuid": "^3.1.0"
+      }
+    },
+    "ics-browser": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/ics-browser/-/ics-browser-2.4.1.tgz",
+      "integrity": "sha512-zHnSx4Ern8+ASKWleJIZBaNfkR1jvOxy88QkWzxe0lPSAWFlZT61U6Fi5R/eLxl8vq028w8gVFxLF06QmuAkRQ==",
+      "requires": {
+        "joi-browser": "^10.6.0",
+        "lodash": "^4.17.4",
+        "moment": "^2.18.1",
+        "uuid": "^3.1.0"
+      }
+    },
+    "ics-js": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/ics-js/-/ics-js-0.10.2.tgz",
+      "integrity": "sha1-1HjqP4MlQKbZQNyjcCA0EqDOadQ=",
+      "requires": {
+        "detect-node": "^2.0.3",
+        "es6-error": "^1.0.0",
+        "lodash.difference": "^4.3.0",
+        "simple-guid": "0.0.1"
+      }
+    },
     "icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -6652,6 +6695,11 @@
         "buffer-alloc": "^1.2.0"
       }
     },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "http://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6746,6 +6794,27 @@
         "istanbul-lib-coverage": "^1.1.1",
         "semver": "^5.3.0"
       }
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+    },
+    "joi": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "requires": {
+        "hoek": "4.x.x",
+        "isemail": "2.x.x",
+        "items": "2.x.x",
+        "topo": "2.x.x"
+      }
+    },
+    "joi-browser": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/joi-browser/-/joi-browser-10.6.1.tgz",
+      "integrity": "sha1-HPwaJEySQjJ4QsJDVNjq0cL+NXE="
     },
     "jquery": {
       "version": "3.2.1",
@@ -7257,6 +7326,11 @@
           "integrity": "sha1-zkKt4IOE711i+nfDD2GkbmhvhDQ="
         }
       }
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -10742,6 +10816,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-guid": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/simple-guid/-/simple-guid-0.0.1.tgz",
+      "integrity": "sha1-1egZ88f3rT0aiCHqtg2P7Q05F+o="
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -11591,6 +11670,14 @@
             "kind-of": "^3.0.2"
           }
         }
+      }
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "requires": {
+        "hoek": "4.x.x"
       }
     },
     "toposort": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "friendly-errors-webpack-plugin": "^1.1.3",
     "html-webpack-plugin": "^3.2.0",
     "http-proxy-middleware": "^0.18.0",
+    "ics-browser": "^2.4.1",
     "inject-loader": "^4.0.1",
     "json-loader": "^0.5.7",
     "karma": "^3.0.0",

--- a/src/components/item.vue
+++ b/src/components/item.vue
@@ -6,6 +6,7 @@
           <div class="ui column four wide">
             <img v-if="event.logo" class="ui tiny circular image fluid" v-bind:src="event.logo" v-bind:alt="event.name">
             <img v-else class="ui tiny circular image fluid" src="../assets/icon.png">
+            <div v-on:click="generateICS($event, event)">Add to calendar</div>
           </div>
           <div class="ui column twelve wide data">
             <h3 class="ui header">
@@ -28,8 +29,20 @@
 
 <script>
 
+import { downloadICS } from '../services/ics-service'
+
 export default {
-  props: ['event']
+  props: ['event'],
+  methods: {
+    generateICS(e, event) {
+      e.preventDefault()
+      try {
+        downloadICS(event)
+      } catch (error) {
+        alert('Could not create calendar event: ' + error)
+      }
+    }
+  }
 }
 </script>
 

--- a/src/services/ics-service.js
+++ b/src/services/ics-service.js
@@ -1,0 +1,43 @@
+import { createEvent } from 'ics-browser'
+
+// Convert a string date DD/MM/YYYY to the array format required by ics-browser
+// Date maniuplation from https://stackoverflow.com/questions/563406
+function convertDate(date, addDays) {
+  const comps = date.split('/').map(d => parseInt(d))
+  let dateArray = [comps[2], comps[1], comps[0]]
+  if (addDays) {
+    const d = new Date(dateArray)
+    d.setDate(d.getDate() + addDays)
+    dateArray = [d.getFullYear(), d.getMonth() + 1, d.getDate()]
+  }
+  return dateArray
+}
+
+// Create a file in memory and download it
+// From https://stackoverflow.com/questions/3665115
+function download(filename, data) {
+  const blob = new Blob([data], {type: 'text/csv'});
+  if(window.navigator.msSaveOrOpenBlob) {
+    window.navigator.msSaveBlob(blob, filename);
+  } else {
+    const elem = window.document.createElement('a');
+    elem.href = window.URL.createObjectURL(blob);
+    elem.download = filename;
+    document.body.appendChild(elem);
+    elem.click();
+    document.body.removeChild(elem);
+  }
+}
+
+// Create and download an ICS calendar entry from an event
+export function downloadICS(event) {
+  const icsEvent = createEvent({
+    title: event.name,
+    start: convertDate(event.start),
+    end: convertDate(event.end, 1),
+    location: event.location,
+    url: event.website
+  })
+  if (icsEvent.error) throw new Error(icsEvent.error)
+  download(event.name + '.ics', icsEvent.value)
+}


### PR DESCRIPTION
This should work with most common calendar systems, including the ones requested in the issue. I have added a simple link below the logo to download the calendar entry. Feel free to replace that link with something more fancy - simply call the method `generateICS` from the improved element.