### PR TITLE
Add conference event

### DIFF
--- a/static/data/2019/10.json
+++ b/static/data/2019/10.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Porto Tech Hub",
+    "start": "11/10/2019",
+    "end": "11/10/2019",
+    "location": "Porto, Portugal",
+    "type": "conference",
+    "website": "https://portotechhub.com/save-the-date-october-11-2019/",
+    "logo": "https://portotechhub.com/wp-content/uploads/2018/06/porto-tech-hub-142x142.jpg"
+  }
+]


### PR DESCRIPTION
This commit adds a conference event for Porto Tech Hub.
![image](https://user-images.githubusercontent.com/13886400/47259789-c89a1180-d4a6-11e8-9b37-a5eb0c2bf5ef.png)
